### PR TITLE
add login page components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3466,6 +3466,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
     },
+    "axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -9730,6 +9752,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.1.3",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.0",

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,0 +1,57 @@
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import styles from './Alert.module.css';
+
+const Alert = ({status, token, action}) => {
+    const [msg, setMsg] = useState("");
+    useEffect(() => getMsg(), [status]);
+    const history = useHistory();
+    
+    const getMsg = () => {
+        switch(status) {
+            case 200:
+                setMsg(`${action}이 완료되었습니다.`);
+                break;
+            case 201:
+                setMsg(`${action}이 완료되었습니다.`);
+                break;
+            case 401:
+                if (action === 'signin') {
+                    setMsg(`회원가입을 먼저 진행해주세요.`);
+                } else {
+                    setMsg(`권한이 없습니다. 로그인 화면으로 이동합니다.`);
+                }
+                break;
+            default:
+                setMsg(`${action} 진행 중 문제가 발생했습니다. 다시 시도해주세요.`);
+        }
+    }
+
+    const redirect = () => {
+        if (status > 200) {
+            window.location.reload("/");
+            return;
+        }
+
+        history.push({pathname: "/todo", state: {token}});
+    }
+
+    return (
+        <div className={styles.alert}>
+            <div>
+                <p className={styles.alert_txt}>{msg}</p>
+                <button className={styles.close_btn} onClick={redirect}>확인</button>
+            </div>
+        </div>
+    )
+}
+
+Alert.propTypes = {
+    status: PropTypes.number.isRequired,
+    token: PropTypes.string.isRequired,
+    action: PropTypes.string.isRequired,
+}
+
+export default Alert

--- a/src/components/Alert.module.css
+++ b/src/components/Alert.module.css
@@ -1,0 +1,37 @@
+.alert {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-top: -75px;
+    margin-left: -300px;
+    width: 600px;
+    height: 200px;
+    background-color: white;
+    box-shadow: 5px 5px 10px 5px rgba(0,0,0,0.2);
+}
+
+.alert_txt {
+    width: 100%;
+    height: 100px;
+    text-align: center;
+    line-height: 100px;
+}
+
+.close_btn {
+    position: absolute;
+    bottom: 10px;
+    left: 190px;
+    width: 220px;
+    height: 50px;
+    background-color: blueviolet;
+    text-align: center;
+    line-height: 30px;
+    color: white;
+}
+
+.close_btn:hover {
+    cursor: pointer;
+    background-color: white;
+    border: 2px solid blueviolet;
+    color: blueviolet;
+}

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -1,6 +1,132 @@
+import { useState } from "react";
+import axios from "axios";
+
+import styles from "./Home.module.css";
+import Alert from "../components/Alert";
+
 const Home = () => {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [isValidEmail, setIsValidEmail] = useState(true);
+    const [isValidPassword, setIsValidPassword] = useState(true);
+    const [action, setAction] = useState("");
+    const [resp, setResp] = useState(0);
+    const [accessToken, setAccessToken] = useState("");
+
+    const signup = async() => {
+        try {
+            setAction("signup");
+
+            const params = {
+                "email": email,
+                "password": password
+            };
+
+            const resp = await axios.post("https://pre-onboarding-selection-task.shop/auth/signup", params);
+            setResp(resp.status);
+            setAccessToken(resp.data.access_token);
+        } catch(e) {
+            setResp(e.response.status);
+        }
+    }
+
+    const signin = async() => {
+        try {
+            setAction("signin");
+
+            const data = {
+                "email": email,
+                "password": password
+            };
+
+            const resp = await axios.post("https://pre-onboarding-selection-task.shop/auth/signin", data);
+            setResp(resp.status);
+            setAccessToken(resp.data.access_token);
+        } catch(e) {
+            setResp(e.response.status);
+        }
+    }
+
+    const updateEmail = (event) => {
+        setEmail(event.target.value);
+
+        if(!email.includes("@")) {
+            setIsValidEmail(false);
+            return;
+        }
+
+        setIsValidEmail(true);
+    }
+
+    const updatePassword = (event) => {
+        setPassword(event.target.value);
+
+        if(password.length < 8) {
+            setIsValidPassword(false);
+            return;
+        }
+
+        setIsValidPassword(true);
+    }
+
     return (
-        <div></div>
+        <div className={styles.bg}>
+            <div className={styles.content}>
+                <h1>TODOS</h1>
+                <h2>로그인</h2>
+                <div>
+                    <input
+                        className={styles.login_input} 
+                        value={email} 
+                        onChange={updateEmail} 
+                        onKeyUp={updateEmail} 
+                        type="text" 
+                        placeholder="이메일을 입력해주세요."
+                    />
+                    {
+                        isValidEmail? 
+                        null: 
+                        <p className={styles.warning}>올바른 이메일 주소를 입력해주세요</p>
+                    }
+                </div>
+                <div>
+                    <input
+                        className={styles.login_input}  
+                        value={password} 
+                        onChange={updatePassword} 
+                        onKeyUp={updatePassword} 
+                        type="password" 
+                        placeholder="비밀번호를 입력해주세요."
+                    />
+                    {
+                        isValidPassword? 
+                        null: 
+                        <p className={styles.warning}>비밀번호는 8자 이상 입력해주세요</p>
+                    }
+                </div>
+                <div className={styles.btn_content}>
+                    <button
+                        className={styles.submit_btn} 
+                        onClick={signin} 
+                        disabled={!isValidEmail || !isValidPassword}
+                    >
+                        로그인
+                    </button>
+                    <button
+                        className={styles.submit_btn}  
+                        onClick={signup} 
+                        disabled={!isValidEmail || !isValidPassword}
+                    >
+                        회원가입
+                    </button>
+                </div>
+            </div>
+            {
+                resp !== 0? 
+                <Alert status={resp} token={accessToken} action={action}/>: 
+                null
+            }
+        </div>
     )
 }
 

--- a/src/routes/Home.module.css
+++ b/src/routes/Home.module.css
@@ -1,0 +1,58 @@
+.bg {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.content {
+    width: 500px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+h1 {
+    text-align: center;
+}
+
+h2 {
+    text-align: center;
+}
+
+.login_input {
+    width: 100%;
+    height: 50px;
+    margin-top: 20px;
+}
+
+.warning {
+    font-size: 12px;
+    color: tomato;
+}
+
+.btn_content {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.submit_btn {
+    width: 220px;
+    height: 50px;
+    background-color: blueviolet;
+    color: white;
+    border: none;
+}
+
+.submit_btn:hover {
+    cursor: pointer;
+}
+
+button:disabled {
+    background-color: #ccc;
+    color: black;
+}


### PR DESCRIPTION
# 로그인 페이지 구현

1. 이메일, 비밀번호 유효성 검사 기능 구현
2. 로그인 API 호출 후 올바른 응답을 받았을 때 `/todo` 경로로 이동
3. access token 로컬에 저장